### PR TITLE
fix lgb.prepare error

### DIFF
--- a/R/LearnerClassifLightGBM.R
+++ b/R/LearnerClassifLightGBM.R
@@ -657,7 +657,7 @@ LearnerClassifLightGBM = R6::R6Class(
       # numeric targets only at the beginning of the training.
 
       # prepare data for lightgbm
-      data = lightgbm::lgb.prepare(data)
+      data = lightgbm::lgb.convert_with_rules(data)[[1]]
 
       # create lightgbm dataset
       private$dtrain = lightgbm::lgb.Dataset(
@@ -744,9 +744,9 @@ LearnerClassifLightGBM = R6::R6Class(
         private$dtrain$get_colnames()
       )
       # create lgb.Datasets
-      test_input = lightgbm::lgb.prepare(
+      test_input = lightgbm::lgb.convert_with_rules(
         newdata
-      )
+      )[[1]]
       test_data = as.matrix(test_input)
       p = mlr3misc::invoke(
         .f = self$model$predict

--- a/R/LearnerRegrLightGBM.R
+++ b/R/LearnerRegrLightGBM.R
@@ -596,7 +596,7 @@ LearnerRegrLightGBM = R6::R6Class(
       label = data[, get(task$target_names)]
 
       # prepare data for lightgbm
-      data = lightgbm::lgb.convert_with_rules(data)[[]]
+      data = lightgbm::lgb.convert_with_rules(data)[[1]]
 
       # create lightgbm dataset
       private$dtrain = lightgbm::lgb.Dataset(

--- a/R/LearnerRegrLightGBM.R
+++ b/R/LearnerRegrLightGBM.R
@@ -596,7 +596,7 @@ LearnerRegrLightGBM = R6::R6Class(
       label = data[, get(task$target_names)]
 
       # prepare data for lightgbm
-      data = lightgbm::lgb.prepare(data)
+      data = lightgbm::lgb.convert_with_rules(data)[[]]
 
       # create lightgbm dataset
       private$dtrain = lightgbm::lgb.Dataset(
@@ -683,9 +683,9 @@ LearnerRegrLightGBM = R6::R6Class(
         private$dtrain$get_colnames()
       )
       # create lgb.Datasets
-      test_input = lightgbm::lgb.prepare(
+      test_input = lightgbm::lgb.convert_with_rules(
         newdata
-      )
+      )[[1]]
       test_data = as.matrix(test_input)
       p = mlr3misc::invoke(
         .f = self$model$predict

--- a/R/backend_preprocessing.R
+++ b/R/backend_preprocessing.R
@@ -80,7 +80,7 @@ backend_preprocessing = function(
   # create backend
   backend = cbind(
     label,
-    lightgbm::lgb.prepare(datatable[, vec, with = F])
+    lightgbm::lgb.convert_with_rules(datatable[, vec, with = F])[[1]]
   )
   colnames(backend)[1] = target_col
 


### PR DESCRIPTION
Substitute lgb.prepare with lgb.convert_with_rules according to changes in **lightgbm** package.
Still need tests, but first example from https://github.com/mlr3learners/mlr3learners.lightgbm/blob/master/vignettes/mlr3learners_lightgbm_early_stopping.Rmd works fine.
I'm going to update other outdated functions in next requests.