### PR TITLE
[docs] Simplify GPU install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ To install the lightgbm R package with GPU support, execute the following comman
 ```bash
 git clone --recursive --branch stable --depth 1 https://github.com/microsoft/LightGBM
 cd LightGBM && \
-sed -i -e 's/use_gpu <- FALSE/use_gpu <- TRUE/g' R-package/src/install.libs.R && \
-Rscript build_r.R
+Rscript build_r.R --use-gpu
 ```
 
 In order to use the GPU acceleration, the parameter `device_type = "gpu"` (default: "cpu") needs to be set. According to the [LightGBM parameter manual](https://lightgbm.readthedocs.io/en/latest/Parameters.html), 'it is recommended to use the smaller `max_bin` (e.g. 63) to get the better speed up'. 

--- a/vignettes/mlr3learners_lightgbm_multiclass_gpu.Rmd
+++ b/vignettes/mlr3learners_lightgbm_multiclass_gpu.Rmd
@@ -28,8 +28,7 @@ You can compile the GPU version on Linux/ in docker with the following commands:
 ```{bash}
 git clone --recursive --branch stable --depth 1 https://github.com/microsoft/LightGBM
 cd LightGBM && \
-sed -i -e 's/use_gpu = FALSE/use_gpu = TRUE/g' R-package/src/install.libs.R && \
-Rscript build_r.R
+Rscript build_r.R --use-gpu
 ```
 
 Then you can install the `mlr3learners.lightgbm` package:


### PR DESCRIPTION
:wave: hello from Chicago!

I recently learned about this project thanks to https://github.com/microsoft/LightGBM/pull/3666.

I read through the README here, and I'm happy to tell you that installing a GPU-enabled version of `{lightgbm}` has gotten a bit easier recently. You no longer need to edit `R-package/src/install.libs.R` with something like `sed`, and can now just pass in the flag `--use-gpu` (https://github.com/microsoft/LightGBM/pull/3574). This PR proposes changing the README to use that instead. I think it's a little simpler and less error prone.

Thanks for all your work and interesting in LightGBM!